### PR TITLE
Fixes a bug where tracking the initial layout wouldn't occur when the…

### DIFF
--- a/Cordate/Sources/Core/Calendar/CalendarDateSelectionController.swift
+++ b/Cordate/Sources/Core/Calendar/CalendarDateSelectionController.swift
@@ -248,10 +248,10 @@ public class CalendarDateSelectionController: UIViewController {
 
     public override func viewDidLayoutSubviews() {
         if !hasLaidOutOnce {
+            hasLaidOutOnce = true
             calendarLayout.setLayoutProperties(for: currentComponent)
             guard case .year = currentComponent, let index = dataSource.indexOfYear(Date().heart.year) else { return }
             calendarView.scrollToItem(at: IndexPath(item: index, section: 0), at: .centeredVertically, animated: false)
-            hasLaidOutOnce = true
         }
     }
 


### PR DESCRIPTION
… calendar began with a date.